### PR TITLE
update test_scatter to avoid redundant tensor allocation

### DIFF
--- a/collective_ops/test_scatter.py
+++ b/collective_ops/test_scatter.py
@@ -11,10 +11,16 @@ shape = (16,2)
 device = torch.device("cuda:{}".format(rank))
 
 output_tensor=torch.zeros((shape[0]//world_size,shape[1]),dtype=torch.int64).to(device)
-tensor_list=[(torch.ones((shape[0]//world_size,shape[1]),dtype=torch.int64)*i).to(device) for i in range(world_size)]
+
+# 在 root 进程中创建一个列表来发送所有张量
+if rank == 0:
+    tensor_list=[(torch.ones((shape[0]//world_size,shape[1]),dtype=torch.int64)*i).to(device) for i in range(world_size)]
 
 # # 打印 scatter 前的张量
-print(f"Rank {rank} before scatter: src_tensor={tensor_list}, recv_tensor={output_tensor}")
+if rank == 0:
+    print(f"Rank {rank} before scatter: scattered_tensors={tensor_list}, recv_tensor={output_tensor}")
+else:
+    print(f"Rank {rank} before scatter: recv_tensor={output_tensor}")
 
 if rank == 0:
     dist.scatter(output_tensor, scatter_list=tensor_list, src=0)


### PR DESCRIPTION
Thanks for your awesome blogs and codes!
In the code of `test_scatter.py`, I find that you create `tensor_list` for all processes. For operator `Scatter`, there should be only one sender, so this code causes redundant tensor allocation for other processes.
I try to fix it by allocating scattered tensors only in the root process (similar to `test_gather.py`), and add some outputs to compare tensors before and after the Scatter operation.